### PR TITLE
将config参数集成到docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
 
 # Copy dependency descriptors first for layer caching
 COPY pyproject.toml poetry.lock ./
+# 新增：将 Git 历史复制进镜像，供 poetry-dynamic-versioning 读取
+COPY .git ./
 
 # Install project dependencies inside an in-project virtualenv
 RUN poetry self add poetry-dynamic-versioning && \


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Copy `.git` directory to the Docker builder stage to fix `poetry-dynamic-versioning` build error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `poetry-dynamic-versioning` plugin requires Git repository information to determine the version during the build process. Previously, the `.git` directory was not copied into the builder stage early enough, leading to the error "This does not appear to be a Git project". This change ensures `.git` is present when the plugin runs, resolving the build failure. The `.git` directory will still be removed later to keep the final image size small.